### PR TITLE
Fix missing "-jar" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ The application fat jars will be placed in:
 
 First you need to run `assembly` in sbt and then run java cmd
 
-    java -Dspark.master=spark://spark-host:7777 order-book-dynamics.jar
+    java -Dspark.master=spark://spark-host:7777 -jar order-book-dynamics.jar


### PR DESCRIPTION
Without it will get an error message like:

Error: Could not find or load main class target.scala-2.10.order-book-dynamics1.jar
